### PR TITLE
Fix SocketError in EC2

### DIFF
--- a/lib/zabbix/sender.rb
+++ b/lib/zabbix/sender.rb
@@ -5,7 +5,12 @@ class Zabbix::Sender
   attr_reader :configured
 
   def initialize(opts={})
-    @client_host = Socket.gethostbyname(Socket.gethostname)[0]
+    begin
+      hostname = Socket.gethostname
+      @client_host = Socket.gethostbyname(hostname)[0]
+    rescue SocketError
+      @client_host = hostname
+    end
 
     if opts[:config_file]
       config = Zabbix::Agent::Configuration.read(opts[:config_file])


### PR DESCRIPTION
I cannot resolve in EC2.

```
$ irb -r socket
irb(main):001:0> Socket.gethostname
=> "ip-10-0-40-10"
irb(main):002:0> Socket.gethostbyname(Socket.gethostname)
SocketError: getaddrinfo: Name or service not known
        from (irb):2:in `gethostbyname'
        from (irb):2
        from /usr/bin/irb:11:in `<main>'
```
